### PR TITLE
Fixed version of the CSP algorithm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+biosig
+======
+
+BioSig - library for biomedical signal processing.
+
+The original repository is available at: https://github.com/donnchadh/biosig.
+Here, I fixed some things that I needed for my master's thesis (https://github.com/piotr-szachewicz/event-related-desynchronization)

--- a/biosig/install.m
+++ b/biosig/install.m
@@ -42,6 +42,7 @@ path([BIOSIG_HOME,'/biosig/doc'],path);		% docus, Eventtable etc.
 path([BIOSIG_HOME,'/biosig/t200_FileAccess'],path);		% dataformat
 path([BIOSIG_HOME,'/biosig/t250_ArtifactPreProcessingQualityControl'],path);		% trigger and quality control
 path([BIOSIG_HOME,'/biosig/t300_FeatureExtraction'],path);		% signal processing and feature extraction
+path([BIOSIG_HOME,'/biosig/t310_ERDSMaps'],path); 
 path([BIOSIG_HOME,'/biosig/t400_Classification'],path);		% classification
 path([BIOSIG_HOME,'/biosig/t450_MultipleTestStatistic'],path);		% statistics, false discovery rates
 path([BIOSIG_HOME,'/biosig/t490_EvaluationCriteria'],path);		% evaluation criteria

--- a/biosig/t300_FeatureExtraction/csp.m
+++ b/biosig/t300_FeatureExtraction/csp.m
@@ -55,9 +55,10 @@ if isempty(Mode),
 	Mode = 'CSP3';
 end; 	
 
-COV = zeros(size(ECM)-[1,1,0]);
+COV = zeros(size(ECM)-[1,1,1]);
 for k=1:sz(1),
-  	[mu,sd,COV(:,:,k),xc,N,R2]=decovm(squeeze(ECM(k,:,:)));
+  	[mu,sd,val,xc,N,R2]=decovm(squeeze(ECM(k,:,:)));
+	COV(k,:,:) = val;
 end; 
 
 
@@ -85,7 +86,10 @@ elseif strcmpi(Mode,'CSP3');
 	%% do actual CSP calculation as generalized eigenvalues
 	%% R = permute(COV,[2,3,1]);
 	for k = 1:sz(1), 
-		[W,D] = eig(COV(:,:,k),sum(COV,3));
+        
+		a = squeeze(COV(k,:,:));
+		b = squeeze(sum(COV,1));
+		[W,D] = eig(a,b);
 		V(:,2*k+[1-p:0]) = W(:,[1,end]);
 	end;
 end; 


### PR DESCRIPTION
Hello, I used the BioSig library for my Master Thesis project and fixed a problem with the CSP algorithm (it didn't work at all for me), and added one missing path to the install.m script.

An example code showing the error with the previous version of the CSP algorithm is presented below:

```
x=rand(10,2);
y=rand(10,2);
r=csp(x,y);
```

Running these 3 lines gives the following error:

```
error: csp_bad: A(I,J,...) = X: dimensions mismatch
error: called from:
error:   /home/kret/programs/biosig-svn/biosig/t300_FeatureExtraction/csp_bad.m at line 60, column 30
```
